### PR TITLE
fix: configure git remote to use RELEASE_TOKEN for pushing

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -173,6 +173,8 @@ jobs:
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
+          # Configure git to use the RELEASE_TOKEN for pushing
+          git remote set-url origin https://x-access-token:${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
 
       - name: Run semantic-release
         env:


### PR DESCRIPTION
Set the git remote URL to use the RELEASE_TOKEN explicitly before running semantic-release. This ensures the token with proper permissions is used for pushing to the protected main branch.