### PR TITLE
feat: add manual trigger to update-changelog workflow

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -3,6 +3,12 @@ name: Update Changelog
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to process (e.g., v1.0.0)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -28,9 +34,11 @@ jobs:
         run: npm ci
 
       - name: Generate changelog
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Get the latest tag
-          LATEST_TAG="${{ github.event.release.tag_name }}"
+          # Get the latest tag (from release event or manual input)
+          LATEST_TAG="${{ github.event.release.tag_name || github.event.inputs.tag }}"
 
           # Get the previous tag
           PREVIOUS_TAG=$(git describe --tags --abbrev=0 ${LATEST_TAG}^ 2>/dev/null || echo "")
@@ -38,7 +46,13 @@ jobs:
           # Create temporary file for new entry
           echo "## ${LATEST_TAG} ($(date +%Y-%m-%d))" > CHANGELOG.tmp
           echo "" >> CHANGELOG.tmp
-          echo "${{ github.event.release.body }}" >> CHANGELOG.tmp
+          # Get release body from event or fetch it for manual runs
+          if [ -n "${{ github.event.release.body }}" ]; then
+            echo "${{ github.event.release.body }}" >> CHANGELOG.tmp
+          else
+            # Fetch release notes for manual trigger
+            gh release view "${LATEST_TAG}" --json body -q .body >> CHANGELOG.tmp
+          fi
           echo "" >> CHANGELOG.tmp
 
           # Handle existing changelog
@@ -56,7 +70,7 @@ jobs:
 
       - name: Update package.json version
         run: |
-          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${{ github.event.release.tag_name || github.event.inputs.tag }}"
           VERSION="${VERSION#v}"  # Remove 'v' prefix if present
           npm version $VERSION --no-git-tag-version
 
@@ -64,16 +78,16 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
-          commit-message: "chore: update changelog and version for ${{ github.event.release.tag_name }}"
-          title: "chore: update changelog and version for ${{ github.event.release.tag_name }}"
+          commit-message: "chore: update changelog and version for ${{ github.event.release.tag_name || github.event.inputs.tag }}"
+          title: "chore: update changelog and version for ${{ github.event.release.tag_name || github.event.inputs.tag }}"
           body: |
-            This PR updates the CHANGELOG.md and package.json version after the release of ${{ github.event.release.tag_name }}.
+            This PR updates the CHANGELOG.md and package.json version after the release of ${{ github.event.release.tag_name || github.event.inputs.tag }}.
 
             This is an automated PR created after the semantic-release process.
 
             - Updates CHANGELOG.md with release notes
             - Updates package.json version to match the release
-          branch: changelog-update-${{ github.event.release.tag_name }}
+          branch: changelog-update-${{ github.event.release.tag_name || github.event.inputs.tag }}
           delete-branch: true
           labels: |
             documentation


### PR DESCRIPTION
- Add workflow_dispatch trigger to test with existing releases
- Handle both automatic (release event) and manual triggers
- Use gh CLI to fetch release notes for manual runs
- Update all template variables to support both trigger types